### PR TITLE
Bundle Assets with Webpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,26 @@
+# OS or Editor folders, misc tmp, swp and other files
 .DS_Store
+.cache
+.project
+.settings
+.tmproj
+nbproject
+Thumbs.db
+build/
+*.diff
+*.err
+*.orig
+*.log
+*.rej
+*.swo
+*.swp
+*.vi
+*~
+*.sass-cache
+.tags*
+
+# NPM packages folder.
+node_modules/
+
+# Compiled Assets
+dist/

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,16 @@
-dev:
-	python -m SimpleHTTPServer
+build: clean webpack assets
+
+clean:
+	rm -rf dist
+
+webpack:
+	npm run build:dist
+
+assets:
+	cp img/* dist/ && cp index.html dist/ && cp favicon.ico dist/
+
+install:
+	npm install
+
+run:
+	npm run dist:server

--- a/README.md
+++ b/README.md
@@ -1,11 +1,28 @@
 ## ACLU People Power event map
-
 More info coming soon...
 
-## Local development
-
-Fire up a local server on port 8000 with:
-
-```bash
-make dev
+## Dev Environment Setup
+Ensure you have node v7.2+ installed on your machine then run
 ```
+npm install
+```
+
+## Local development server
+Start up a local development server with hot-reloading
+```
+npm start
+```
+
+## Compile assets for production deployment
+Assets will compiled to the dist dir by default.
+```
+make build
+```
+
+To run a simple webserver with the dist dir as root use:
+```
+make run
+```
+
+## Deployment
+TBD

--- a/config/common.js
+++ b/config/common.js
@@ -1,0 +1,79 @@
+const path = require('path');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+//Directory that webpack should compile assets to
+const DIST_PATH = process.env.DIST_PATH || path.resolve(__dirname, '../dist');
+
+//base URL path to where all assets will be hosted
+const ASSET_PATH = process.env.ASSET_PATH || '/';
+
+module.exports = function(env){
+  console.log("ENV CHECK: ", env !== "production")
+  return {
+    entry: './js/index.js',
+    output: {
+      filename: 'bundle.js',
+      path: DIST_PATH,
+      publicPath: ASSET_PATH
+    },
+    devtool: 'cheap-module-eval-source-map',
+    module: {
+      rules: [
+        //Transpile JS with babel
+        //FIXME on node 7+ this currently outputs (harmless) deprecation warning
+        //caused by: https://github.com/babel/babel-loader/pull/391
+        //Once new babel-loader is release, we should upgrade and remove this comment
+        {
+          test: /.js$/,
+          exclude: /node_modules/,
+          loader: 'babel-loader',
+          options: {
+            presets: ['env']
+          }
+        },
+        {
+          //Compile sass files, then run through autoprefixer
+          test: /\.scss$/,
+          use: ExtractTextPlugin.extract({
+            fallback: 'style-loader',
+            use: [
+              'css-loader',
+              {
+                loader: 'postcss-loader',
+                options: {
+                  plugins: function(){return [require('autoprefixer')]}
+                }
+              },
+              'sass-loader',
+            ]
+          })
+        },
+        //Inline very small font files (less than 5kb), otherwise just save
+        //to output dir as normal files
+        {
+          test: /\.(eot|ttf|woff|woff2)$/,
+          loader: 'url-loader',
+          options: {
+            limit: 5000,
+            name: './fonts/[name].[ext]',
+          },
+        },
+        //inline assests smaller than 10kb, otherwise copy them as files to output dir
+        {
+          test: /\.(jpg|png|svg)$/,
+          loader: 'url-loader',
+          options: {
+            limit: 10000,
+            name: './img/[name].[ext]'
+          },
+        },
+      ]
+    },
+    plugins: [
+      new ExtractTextPlugin({
+        filename: "styles.css",
+        disable: (env === "production")
+      }),
+    ]
+  }
+}

--- a/config/dev.js
+++ b/config/dev.js
@@ -1,0 +1,10 @@
+const webpackMerge = require('webpack-merge');
+const commonConfig = require('./common.js');
+const webpack = require('webpack');
+
+module.exports = function(env) {
+  return webpackMerge(commonConfig(env), {
+    stats: 'errors-only',
+    devtool: 'cheap-module-eval-source-map',
+  })
+};

--- a/config/prod.js
+++ b/config/prod.js
@@ -1,0 +1,32 @@
+const webpackMerge = require('webpack-merge');
+const commonConfig = require('./common.js');
+const webpack = require('webpack');
+
+module.exports = function(env){
+  return webpackMerge(commonConfig(env), {
+    devtool: 'source-map',
+    plugins: [
+      new webpack.LoaderOptionsPlugin({
+        minimize: true,
+        debug: false
+      }),
+      new webpack.DefinePlugin({
+        'process.env': {
+            'NODE_ENV': JSON.stringify('production')
+        }
+      }),
+      new webpack.optimize.UglifyJsPlugin({
+        beautify: false,
+        mangle: {
+          screw_ie8: true,
+          keep_fnames: true
+        },
+        compress: {
+          screw_ie8: true,
+          warnings: false
+        },
+        comments: false
+      })
+    ]
+  })
+}

--- a/css/fonts.scss
+++ b/css/fonts.scss
@@ -1,13 +1,3 @@
-/**
- * COLORS
- *
- * #EF4134 red
- * #272F32 dark
- * #537882 blue
- * #9DBDC6 blue light
- * #ECECEC off-white
- */
-
 @font-face {
   font-family: "Freight Sans CMP";
   font-style: normal;
@@ -41,67 +31,4 @@
     url('../fonts/icomoon.svg?a4ftzs#icomoon') format('svg');
   font-weight: normal;
   font-style: normal;
-}
-
-[class^="icon-"], [class*=" icon-"] {
-  /* use !important to prevent issues with browser extensions that change fonts */
-  font-family: 'icomoon' !important;
-  speak: none;
-  font-style: normal;
-  font-weight: normal;
-  font-variant: normal;
-  text-transform: none;
-  line-height: 1;
-
-  /* Better Font Rendering =========== */
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-.icon-x:before {
-  content: "\e900";
-}
-.icon-search:before {
-  content: "\e986";
-}
-.icon-star-full:before {
-  content: "\e9d9";
-}
-
-.btn {
-  background: #537882;
-}
-
-.btn:hover {
-  cursor: pointer;
-}
-
-.btn.-primary {
-  background: #EF4134;
-}
-
-body {
-  font-family: "Freight Sans CMP";
-  font-size: 16px;
-}
-
-.header {
-  padding: 1em;
-  text-align: center;
-  background: #272F32;
-}
-
-.logo {
-  max-width: 300px;
-}
-
-.cta {
-  color: white;
-  font-size: 2rem;
-}
-
-.map {
-  background: #9DBDC6;
-  padding: 8rem;
-  text-align: center;
 }

--- a/css/icons.scss
+++ b/css/icons.scss
@@ -1,0 +1,24 @@
+[class^="icon-"], [class*=" icon-"] {
+  /* use !important to prevent issues with browser extensions that change fonts */
+  font-family: 'icomoon' !important;
+  speak: none;
+  font-style: normal;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
+  line-height: 1;
+
+  /* Better Font Rendering =========== */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.icon-x:before {
+  content: "\e900";
+}
+.icon-search:before {
+  content: "\e986";
+}
+.icon-star-full:before {
+  content: "\e9d9";
+}

--- a/css/index.scss
+++ b/css/index.scss
@@ -1,0 +1,4 @@
+@import "~normalize.css";
+@import "fonts";
+@import "icons";
+@import "map";

--- a/css/map.scss
+++ b/css/map.scss
@@ -1,0 +1,39 @@
+@import "variables";
+
+.btn {
+  background: $light-blue;
+}
+
+.btn:hover {
+  cursor: pointer;
+}
+
+.btn.-primary {
+  background: $light-blue;
+}
+
+body {
+  font-family: "Freight Sans CMP";
+  font-size: 16px;
+}
+
+.header {
+  padding: 1em;
+  text-align: center;
+  background: $off-white;
+}
+
+.logo {
+  max-width: 300px;
+}
+
+.cta {
+  color: $blue;
+  font-size: 2rem;
+}
+
+.map {
+  background: $blue;
+  padding: 8rem;
+  text-align: center;
+}

--- a/css/variables.scss
+++ b/css/variables.scss
@@ -1,0 +1,5 @@
+$red: #EF4134;
+$dark: #272F32;
+$blue: #537882;
+$light-blue: #9DBDC6;
+$off-white: #ECECEC;

--- a/index.html
+++ b/index.html
@@ -4,10 +4,11 @@
   <meta charset="utf-8" />
   <title>ACLU People Power Map</title>
   <meta name="description" content="Stuff" />
-  <link rel="stylesheet" href="./css/style.css" />
 
   <!-- FIXME is this a CDN? Maybe fetch from someplace else  -->
   <link href='https://api.mapbox.com/mapbox.js/v3.0.1/mapbox.css' rel='stylesheet' />
+  <link href='styles.css' rel='stylesheet' />
+
 </head>
 
 <body>
@@ -29,14 +30,12 @@
   </div>
   <div class="map">
     <h2>Imagine a map</h2>
+    <div id="webpack-test">
+    </div>
   </div>
 
-  <!-- FIXME bundle third party JS dependencies and serve them ourselves. 
-       For now, just put them in here.  -->
+  <!-- FIXME Not bundling mapbox.js since unclear if we will use this or mapbox gl -->
   <script src="https://api.mapbox.com/mapbox.js/v3.0.1/mapbox.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js"></script>
-  <!-- etc -->
-
-  <script src="./js/index.js"></script>
+  <script src="bundle.js"></script>
 </body>
 </html>

--- a/js/index.js
+++ b/js/index.js
@@ -1,0 +1,4 @@
+require('../css/index.scss');
+let moment = require('moment');
+
+document.getElementById("webpack-test").innerHTML="Webpack is running. The time is: " + moment().format('h:mm:ss a');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "map",
+  "version": "1.0.0",
+  "description": "ACLU People Power Map",
+  "main": "index.js",
+  "scripts": {
+    "start": "webpack-dev-server --env=dev --hot",
+    "test": "",
+    "build:dev": "webpack --env=dev --colors",
+    "build:dist": "webpack --env=prod --colors && cp -r img dist/img && cp index.html dist/",
+    "dist:server": "pushd dist; python -m SimpleHTTPServer; popd"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aclu-people-power/map.git"
+  },
+  "author": "ACLU",
+  "license": "UNLICENSED",
+  "bugs": {
+    "url": "https://github.com/aclu-people-power/map/issues"
+  },
+  "homepage": "https://github.com/aclu-people-power/map#readme",
+  "devDependencies": {
+    "babel-core": "^6.24.0",
+    "babel-loader": "^6.4.1",
+    "babel-preset-env": "^1.2.2",
+    "css-loader": "^0.27.3",
+    "extract-text-webpack-plugin": "^2.1.0",
+    "file-loader": "^0.10.1",
+    "moment": "^2.18.1",
+    "node-sass": "^4.5.1",
+    "nodemon": "^1.11.0",
+    "normalize.css": "^5.0.0",
+    "postcss-loader": "^1.3.3",
+    "sass-loader": "^6.0.3",
+    "style-loader": "^0.16.0",
+    "url-loader": "^0.5.8",
+    "webpack": "^2.3.1",
+    "webpack-dev-server": "^2.4.2",
+    "webpack-merge": "^4.1.0"
+  },
+  "dependencies": {
+    "moment": "^2.18.1"
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,5 @@
+function buildConfig(env) {
+  return require('./config/' + env + '.js')(env)
+}
+
+module.exports = buildConfig;


### PR DESCRIPTION
Fixes #17 

Full Change List:
- Added NPM package file
- Added SCSS compilation ability, split style.css into smaller scss
  files
- Added Postcss autoprefixing for better browser compatibility
- Added Babel for better browser compatibility
- Added Normalize.css for more consistent styling
- Added webpack-dev-server for hot-reloading of assets
- Added production webpack config to minify & uglify JS

For future
- Asset hashing (to better break caches)
- Front End Framework (Vue? React?) Integration
- Determine how / if bundle.js should be split for best performance
- Revisit final buildchain/process (Makefiles aren't my favorite... could do most everything with webpack if we wanted, tbd)