### PR TITLE
Routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "babel-core": "^6.24.0",
     "babel-loader": "^6.4.1",
     "babel-preset-env": "^1.2.2",
+    "babel-preset-es2015": "^6.24.0",
+    "babel-preset-stage-0": "^6.22.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.27.3",
     "extract-text-webpack-plugin": "^2.1.0",
@@ -48,7 +50,6 @@
   "dependencies": {
     "moment": "^2.18.1",
     "mapbox.js": "^3.0.1",
-    "moment": "^2.18.1",
     "vue": "^2.2.5"
   }
 }

--- a/src/index.html.ejs
+++ b/src/index.html.ejs
@@ -21,7 +21,7 @@
     <h2 class="cta">Find events near you</h2>
     <div class="toolbar">
       <div>
-        <input type="text" placeholder="Search by zip code" />
+        <input id="zipcode" type="text" placeholder="Search by zip code" />
         <button type="button" class="btn -primary">
           <i class="icon-search"></i>
         </button>

--- a/src/index.js
+++ b/src/index.js
@@ -17,14 +17,23 @@ window.setHash = setHash;
 
 // Boot:
 
+
 // FIXME this stuff will move into the map component
+let eventsLayer = null;
+
 function plotAndZoom(filters) {
 
-  // first we compute the filtered event set
+  // wipe out existing plotted events -- probably this can
+  // be done more efficiently
+  if (eventsLayer) {
+    eventsLayer.clearLayers();
+  }
+
+  // compute filtered event set
   const filteredEvents = getFilteredEvents(window.PEOPLEPOWER_EVENTS, filters);
 
   // then plot those events
-  plotEvents(filteredEvents, window.map);
+  eventsLayer = plotEvents(filteredEvents, window.map);
 
   // then adjust map position accordingly
   setMapPositionBasedOnZip(

--- a/src/index.js
+++ b/src/index.js
@@ -3,13 +3,21 @@ import { getFilteredEvents } from './util/event-utils';
 import { plotEvents, setMapPositionBasedOnZip } from './util/map-utils';
 import { getHash, setHash, onHashChange } from './util/url-hash';
 
-// FIXME DEBUG this is just here to poke around with and set event
-// filters via the JS console.
+// temporary thing so that changing zipcode via UI updates query
+document.getElementById('zipcode').addEventListener('input', (event) => {
+  const value = event.target.value;
+  if (/^\d+$/.test(value) && value.length === 5) {
+    setHash({ zipcode: value });
+  }
+});
+
+// temporary thing for setting event type and start/end dates via JS
+// console, e.g. setHash({ eventType: 'hi', startDate: '2017-03-21'})
 window.setHash = setHash;
 
 // Boot:
 
-// This will move into the map component
+// FIXME this stuff will move into the map component
 function plotAndZoom(filters) {
 
   // first we compute the filtered event set
@@ -32,8 +40,6 @@ plotAndZoom(getHash());
 
 // Also when the event filters change
 onHashChange(plotAndZoom);
-
-// TODO translate back and forth with date range into two fields
 
 // Start up Vue
 import Vue from 'vue';

--- a/src/index.js
+++ b/src/index.js
@@ -1,32 +1,39 @@
 import moment from 'moment';
 import { getFilteredEvents } from './util/event-utils';
 import { plotEvents, setMapPositionBasedOnZip } from './util/map-utils';
+import { getHash, setHash, onHashChange } from './util/url-hash';
 
+// FIXME DEBUG this is just here to poke around with and set event
+// filters via the JS console.
+window.setHash = setHash;
 
 // Boot:
 
-// (the url will be the source of truth for these values. here
-//  we are just faking it)
-const filters = {
-  eventType: null,
-  dateRange: null,
-  zipcode: null,
-};
+// This will move into the map component
+function plotAndZoom(filters) {
 
-// first we compute the filtered event set
-const filteredEvents = getFilteredEvents(window.PEOPLEPOWER_EVENTS, filters);
+  // first we compute the filtered event set
+  const filteredEvents = getFilteredEvents(window.PEOPLEPOWER_EVENTS, filters);
 
-// then plot those events
-plotEvents(filteredEvents, window.map);
+  // then plot those events
+  plotEvents(filteredEvents, window.map);
 
-// then adjust map position accordingly
-setMapPositionBasedOnZip(
-  filters.zipcode,
-  window.KNOWN_ZIPCODES,
-  filteredEvents,
-  window.map
-);
+  // then adjust map position accordingly
+  setMapPositionBasedOnZip(
+    filters.zipcode,
+    window.KNOWN_ZIPCODES,
+    filteredEvents,
+    window.map
+  );
+}
 
+// Once initially on boot, based on initial filters in URL
+plotAndZoom(getHash());
+
+// Also when the event filters change
+onHashChange(plotAndZoom);
+
+// TODO translate back and forth with date range into two fields
 
 // Start up Vue
 import Vue from 'vue';

--- a/src/util/event-utils.js
+++ b/src/util/event-utils.js
@@ -1,23 +1,36 @@
+import moment from 'moment';
+
 export function getFilteredEvents(events, filters) {
 
   // Bail out early if possible. Huge array!
-  if (!filters.eventType && !filters.dateRange) {
+  if (!filters.eventType && !filters.startDate && !filters.endDate) {
     return events;
   }
 
-  return events.filter(function(ppEvent) {
+  return events.filter(function(event) {
 
-    if (filters.eventType && filters.eventType !== ppEvent.event_type) {
+    // should maybe be using event.categories, not sure
+    if (filters.eventType && filters.eventType !== event.event_type) {
       return false;
     }
 
-    // note: there is also a utc timestamp, this is localized
-    const localDatetime = moment(ppEvent.start_datetime);
+    // note: there is also a utc timestamp, this one is localized
+    const localDatetime = moment(event.start_datetime);
+
+    if (filters.startDate) {
+      const startDate = moment(filters.startDate, 'YYYY-MM-DD');
+
+      if (localDatetime.isBefore(startDate)) {
+        return false;
+      }
+    }
+
+    if (filters.endDate) {
+      const endDate = moment(filters.endDate, 'YYYY-MM-DD');
     
-    if (filters.dateRange && 
-        ((filters.dateRange.start && localDatetime.isBefore(filters.dateRange.start)) ||
-        (filters.dateRange.end && localDatetime.isAfter(filters.dateRange.end)))) {
-      return false;
+      if (localDatetime.isAfter(endDate)) {
+        return false;
+      }
     }
 
     return true;

--- a/src/util/map-utils.js
+++ b/src/util/map-utils.js
@@ -1,18 +1,18 @@
 export function plotEvents(events, map) {
-  const overlays = L.layerGroup().addTo(map);
+  const layer = L.layerGroup().addTo(map);
 
-  events.forEach(function(ppEvent) {
-    L.circleMarker([ppEvent.lat, ppEvent.lng], {
+  events.forEach(function(event) {
+    L.circleMarker([event.lat, event.lng], {
       radius: 5,
       color: 'white',
       fillColor: '#ef3030',
       opacity: 0.8,
       fillOpacity: 0.7,
       weight: 2
-    }).addTo(overlays);
+    }).addTo(layer);
   });
 
-  return overlays;
+  return layer;
 }
 
 export function setMapPositionBasedOnZip(zipcode, knownZipcodes, events, map) {

--- a/src/util/url-hash.js
+++ b/src/util/url-hash.js
@@ -1,0 +1,36 @@
+import querystring from 'querystring';
+
+/**
+ * Get the hash params, parsed into an object.
+ */
+export function getHash() {
+  return querystring.parse(window.location.hash.replace(/^#/, ''))
+}
+
+/**
+ * Set hash query params with an object
+ */
+export function setHash(params = {}) {
+  const existingParams = getHash();
+
+  window.location.hash = querystring.stringify(Object.assign({},
+    existingParams,
+    params
+  ));
+}
+
+let handleHashChange = null;
+
+window.onhashchange = event => {
+  if (handleHashChange) {
+    handleHashChange(getHash());
+  }
+}
+
+/**
+ * Assign a listener on hash change -- it will receive the parsed
+ * hash of event filters as its only arg.
+ */
+export function onHashChange(fn) {
+  handleHashChange = fn;
+}


### PR DESCRIPTION
Toward #22 

This wires up a super simple router-like thing, which is basically just an observable query string after the url hash. The event filters are the parameters. For example:

```
http://localhost:8080/#zipcode=53211&endDate=2017-03-29
```
Includes functions to get/set the query params, as well as a way to register a listener for when the hash changes.

Using a hash vs html 5 history api because we are supporting IE9.

To have a functional proto to play around with, this also wires up a console interface (as well as the zipcode text input UI) to update the query string, and also sets up the map to listen to changes in the query string and update itself accordingly. [Video demo](https://www.dropbox.com/s/d33yaulfohujq7h/aclu-map-routing.mov?dl=0).