### PR TITLE
Remove latency from filter interaction

### DIFF
--- a/src/components/EventDateFilters.vue
+++ b/src/components/EventDateFilters.vue
@@ -63,8 +63,8 @@ export default {
       get() {
         return forDisplay(this.$store.state.filters.startDate);
       },
-      set(value) {
-        this.$store.commit('setFilters',{ startDate: value });
+      set(value){
+        this.$store.dispatch('setFilters',{ startDate: value });
       }
     },
     isActive: function() { return !!this.currentCalendar },
@@ -73,7 +73,7 @@ export default {
         return forDisplay(this.$store.state.filters.endDate);
       },
       set(value){
-        this.$store.commit('setFilters',{ endDate: value })
+        this.$store.dispatch('setFilters',{ endDate: value })
       }
     }
   },

--- a/src/components/EventTypeFilters.vue
+++ b/src/components/EventTypeFilters.vue
@@ -36,7 +36,7 @@ export default {
         return this.filters.eventType ? this.filters.eventType.split(',') : []
       },
       set(newEventTypes){
-        this.$store.commit('setFilters',{ eventType: newEventTypes.join(',') });
+        this.$store.dispatch('setFilters',{ eventType: newEventTypes.join(',') });
       }
     }
   }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -37,7 +37,7 @@ export default function(store){
         const newZipcode = e.target.value;
 
         if (/^\d{5}$/.test(newZipcode) || !newZipcode) {
-          store.commit('setFilters',{zipcode: newZipcode });
+          store.dispatch('setFilters',{zipcode: newZipcode });
         }
       }
     },

--- a/src/store.js
+++ b/src/store.js
@@ -48,6 +48,15 @@ const store = new Vuex.Store({
         if (err) return;
         commit('zipcodesReceived', response.body);
       });
+    },
+    setFilters({ commit }, filters) {
+      // Pushing this to the next tick because it triggers a large
+      // workload which can momentarily block the UI interaction that
+      // initiated it and feel laggy. The reason this is split into
+      // an action and a mutation is to facilitate this nextTick-ing.
+      process.nextTick(() => {
+        commit('filtersReceived', filters);
+      });
     }
   },
   mutations: {
@@ -60,7 +69,7 @@ const store = new Vuex.Store({
     viewToggled(state) {
       state.view = state.view === 'map' ? 'list' : 'map';
     },
-    setFilters(state, filters) {
+    filtersReceived(state, filters) {
       state.filters = {...state.filters, ...filters};
     },
     eventSelected(state, eventId) {

--- a/src/store.js
+++ b/src/store.js
@@ -12,7 +12,7 @@ const initialHash = querystring.parse(window.location.hash.replace(/^#/, ''))
 //the setFilters mutation occurs
 const hashUpdaterPlugin = (store) => {
   store.subscribe((mutation, state) => {
-    if(mutation.type === "setFilters"){
+    if(mutation.type === "filtersReceived"){
       window.location.hash = querystring.stringify(state.filters)
     }
   })


### PR DESCRIPTION
The superior data flow situation created by #63 also introduced a minor issue: a lot of blocking work is performed at the moment the event filters change, and the UI interaction is laggy. For example, if you click on an event type checkbox, or if you type the fifth digit of a zipcode, there is a noticeable lag in UI feedback, for example until the box is checked or the digit shows up, while the new set of filtered events is being computed.

This PR presents a gross way to deal with that using process.nextTick. I'd love to hear other ideas, I'm not sure if there is a more appropriate way to solve this using vue/vuex.