### PR TITLE
Tweak to unbreak bundle

### DIFF
--- a/config/prod.js
+++ b/config/prod.js
@@ -10,6 +10,12 @@ module.exports = function(env){
       filename: '[name].[chunkhash].js'
     },
     devtool: 'source-map',
+    // Uglify is blowing up trying to further minify mapbox-gl
+    // so for now just do not parse it -- it is already minified.
+    // https://github.com/mapbox/mapbox-gl-js/issues/4359
+    module: {
+      noParse: /(mapbox-gl)\.js$/,
+    },
     plugins: [
       new webpack.LoaderOptionsPlugin({
         minimize: true,


### PR DESCRIPTION
The production build is throwing a JS error, it's kind of a long story, but the short version is that there's either an uglify or webpack bug probably that is choking on something in mapbox-gl. This PR just skips parsing and minifying mapbox-gl cause it's already minified.

See https://github.com/mapbox/mapbox-gl-js/issues/4359