### PR TITLE
Event card updates

### DIFF
--- a/src/assets/styles/event_list.scss
+++ b/src/assets/styles/event_list.scss
@@ -1,5 +1,9 @@
 @import "~styles/variables";
 
+.event-list {
+  position: relative;
+}
+
 .event-list-item {
   border-top: solid 2px $gray;
   &:first-child {
@@ -22,6 +26,11 @@
     border-left: solid 2px $gray;
     .event-list-item {
       padding: 0 2em;
+    }
+  }
+  .event-list-item {
+    &.-selected {
+      border-left: solid 5px $aclu-blue;
     }
   }
 }

--- a/src/assets/styles/event_list.scss
+++ b/src/assets/styles/event_list.scss
@@ -22,7 +22,6 @@
 
 @media (min-width: $breakpoint-large) {
   .event-list {
-    border-top: solid 2px $gray;
     border-left: solid 2px $gray;
     .event-list-item {
       padding: 0 2em;

--- a/src/assets/styles/event_list.scss
+++ b/src/assets/styles/event_list.scss
@@ -22,12 +22,12 @@
 
 @media (min-width: $breakpoint-large) {
   .event-list {
-    border-left: solid 2px $gray;
     .event-list-item {
       padding: 0 2em;
     }
   }
   .event-list-item {
+    border-left: solid 2px $gray;
     &.-selected {
       border-left: solid 5px $aclu-blue;
     }

--- a/src/assets/styles/header.scss
+++ b/src/assets/styles/header.scss
@@ -287,6 +287,7 @@
     display: block;
     background: $white;
     padding: $offset;
+    border-bottom: solid 2px $light-gray;
   }
 
   .toolbar-inner {

--- a/src/components/EventCard.vue
+++ b/src/components/EventCard.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="event-card inner-wrap">
-    <div v-if="labels.length" class="event-card-labels">
-      <span v-for="label in labels" class="event-card-label">
+    <div v-if="hasLabels" class="event-card-labels">
+      <span v-if="event.is_official" class="event-card-label">
+        <i class="icon-star-full"></i> Official ACLU Event
+      </span>
+      <span v-for="label in categoryLabels" class="event-card-label">
         {{label}}
       </span>
     </div>
@@ -38,14 +41,15 @@ export default {
     hasCapacity() {
       return this.event.attendee_count < this.event.max_attendees;
     },
-    labels() {
-      if (!this.event.categories) {
-        return [];
-      }
+    hasLabels() {
+      return this.event.is_official || this.event.categories;
+    },
+    categoryLabels() {
+      const categories = this.event.categories ?
+        this.event.categories.split(',') :
+        [];
 
-      return this.event.categories.split(',')
-        .map(event => eventTypes[event])
-        .filter(Boolean);
+      return categories.map(event => eventTypes[event]).filter(Boolean);
     },
     url() {
       return `https://go.peoplepower.org/event/${this.event.campaign}/${this.event.id}`;

--- a/src/components/EventCard.vue
+++ b/src/components/EventCard.vue
@@ -15,7 +15,7 @@
       {{event.venue}}
     </div>
     <div v-if="hasCapacity">
-      <a class="btn event-card-cta" v-bind:href="event.url" target="_blank">RSVP</a>
+      <a class="btn event-card-cta" :href="url" target="_blank">RSVP</a>
     </div>
   </div>
 </template>
@@ -46,6 +46,9 @@ export default {
       return this.event.categories.split(',')
         .map(event => eventTypes[event])
         .filter(Boolean);
+    },
+    url() {
+      return `https://go.peoplepower.org/event/${this.event.campaign}/${this.event.id}`;
     }
   }
 }

--- a/src/components/EventList.js
+++ b/src/components/EventList.js
@@ -39,13 +39,6 @@ export default function(store){
         return "Invalid zipcode."
       },
     },
-    methods: {
-      scrollIntoView(offsetTop) {
-        if (this.$refs.root) {
-          this.$refs.root.scrollTop = offsetTop + 2;
-        }
-      }
-    },
     components: {
       'event-card': EventCard,
       'event-list-item': EventListItem

--- a/src/components/EventList.js
+++ b/src/components/EventList.js
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import EventCard from 'src/components/EventCard';
+import EventListItem from 'src/components/EventListItem';
 
 export default function(store){
   return new Vue({
@@ -23,6 +24,9 @@ export default function(store){
       view() {
         return store.state.view;
       },
+      selectedEventId() {
+        return store.state.selectedEventId;
+      },
       isSelectedZipcodeInvalid() {
         return this.filters.zipcode &&
           this.zipcodes &&
@@ -33,10 +37,18 @@ export default function(store){
       },
       invalidZipcodeText() {
         return "Invalid zipcode."
+      },
+    },
+    methods: {
+      scrollIntoView(offsetTop) {
+        if (this.$refs.root) {
+          this.$refs.root.scrollTop = offsetTop + 2;
+        }
       }
     },
     components: {
-      'event-card': EventCard
+      'event-card': EventCard,
+      'event-list-item': EventListItem
     }
   })
 }

--- a/src/components/EventListItem.vue
+++ b/src/components/EventListItem.vue
@@ -11,7 +11,7 @@ export default {
   watch: {
     selected() {
       if (this.selected) {
-        this.onSelect(this.$refs.root.offsetTop);
+        this.$refs.root.scrollIntoView({ behavior: 'smooth' });
       }
     }
   }

--- a/src/components/EventListItem.vue
+++ b/src/components/EventListItem.vue
@@ -1,0 +1,19 @@
+<template>
+  <div ref="root" :class="['event-list-item', { '-selected': selected }]">
+    <slot></slot>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'event-list-item',
+  props: ['selected', 'onSelect'],
+  watch: {
+    selected() {
+      if (this.selected) {
+        this.onSelect(this.$refs.root.offsetTop);
+      }
+    }
+  }
+}
+</script>

--- a/src/store.js
+++ b/src/store.js
@@ -25,8 +25,8 @@ const store = new Vuex.Store({
     events: [],
     zipcodes: {},
     view: 'map',
-    filters: initialHash
-
+    filters: initialHash,
+    selectedEventId: null
   },
   actions: {
     loadEvents({commit}){
@@ -63,6 +63,9 @@ const store = new Vuex.Store({
     setFilters(state, filters) {
       state.filters = {...state.filters, ...filters};
     },
+    eventSelected(state, eventId) {
+      state.selectedEventId = eventId;
+    }
   },
   getters: {
     filteredEvents: state => {

--- a/src/templates/EventList.html
+++ b/src/templates/EventList.html
@@ -1,14 +1,18 @@
-<div id="event-list" :class="['event-list', { '-active': view === 'list'}]">
-  <div v-for="event in filteredEvents" class="event-list-item">
+<div id="event-list" ref="root" :class="['event-list', { '-active': view === 'list'}]">
+  <event-list-item
+    v-for="event in filteredEvents"
+    :selected="event.id === selectedEventId"
+    :onSelect="scrollIntoView"
+  >
     <event-card v-bind:event="event"></event-card>
-  </div>
-  <div 
-    v-if="isSelectedZipcodeInvalid" 
+  </event-list-item>
+  <div
+    v-if="isSelectedZipcodeInvalid"
     class="event-list-empty"
     v-html="invalidZipcodeText"
   >
   </div>
-  <div 
+  <div
     v-else-if="events.length && !filteredEvents.length"
     class="event-list-empty"
     v-html="noEventsText"

--- a/src/templates/EventList.html
+++ b/src/templates/EventList.html
@@ -1,8 +1,7 @@
-<div id="event-list" ref="root" :class="['event-list', { '-active': view === 'list'}]">
+<div id="event-list" :class="['event-list', { '-active': view === 'list'}]">
   <event-list-item
     v-for="event in filteredEvents"
     :selected="event.id === selectedEventId"
-    :onSelect="scrollIntoView"
   >
     <event-card v-bind:event="event"></event-card>
   </event-list-item>

--- a/src/util/events.js
+++ b/src/util/events.js
@@ -20,18 +20,28 @@ export function computeFilteredEvents(events, filters, zipcodes) {
   return events.filter(function(event) {
 
     if (filters.eventType) {
-      if (!event.categories) {
+      const eventCategories = event.categories ?
+        event.categories.split(',') :
+        [];
+
+      // The UI lumps into "event types" what are mostly "categories"
+      // in ActionKit, with this one exception, the is_official
+      // boolean field, so we will just pretend it is a category.
+      if (event.is_official) {
+        eventCategories.push('aclu');
+      }
+
+      if (!eventCategories.length) {
         return false;
       }
 
-      const allCategories = event.categories.split(',');
-      const allEventTypes = filters.eventType.split(',');
+      const selectedEventTypes = filters.eventType.split(',');
 
-      const eventIsInNoSelectedCategories = allEventTypes.every(type =>
-        !allCategories.includes(type)
+      const eventMatchesNoSelectedTypes = selectedEventTypes.every(
+        type => !eventCategories.includes(type)
       );
 
-      if (eventIsInNoSelectedCategories) {
+      if (eventMatchesNoSelectedTypes) {
         return false;
       }
     }
@@ -74,6 +84,7 @@ export function computeFilteredEvents(events, filters, zipcodes) {
 }
 
 export const eventTypes = {
+  aclu: "Official ACLU Event",
   freedomcities: "Freedom Cities Action",
   muslimban: "Muslim Ban Action",
   protestrally: "Protest/Rally",


### PR DESCRIPTION
Closes #59 

- Updates method for generating urls to events
- Adds "official aclu" pseudo event type, so user can filter by it; also adds a label with a star in the event card
- Adds style for a "selected event" and makes the event list respond to a new event being selected by scrolling it into view in the list. Now when the map piece is wired up to select events when they're clicked, this will work.