### PR TITLE
Show list view initially

### DIFF
--- a/src/components/EventMap.js
+++ b/src/components/EventMap.js
@@ -76,6 +76,13 @@ export default function(store){
         if (newFilters.zipcode !== oldFilters.zipcode) {
           this.setMapPositionBasedOnZip();
         }
+      },
+
+      // when the map is toggled to, make sure to resize accordingly
+      view(newView, oldView) {
+        if (newView === 'map' && this.mapRef) {
+          Vue.nextTick(() => this.mapRef.resize());
+        }
       }
     },
     methods: {

--- a/src/components/EventMap.js
+++ b/src/components/EventMap.js
@@ -80,7 +80,7 @@ export default function(store){
 
       // when the map is toggled to, make sure to resize accordingly
       view(newView, oldView) {
-        if (newView === 'map' && this.mapRef) {
+        if (newView !== oldView && newView === 'map' && this.mapRef) {
           Vue.nextTick(() => this.mapRef.resize());
         }
       }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import EventTypeFilters from 'src/components/EventTypeFilters';
 import EventDateFilters from 'src/components/EventDateFilters';
 import ButtonDropdown from 'src/components/ButtonDropdown';
+import MobileEventFilters from 'src/components/MobileEventFilters';
 
 export default function(store){
   return new Vue({
@@ -45,6 +46,7 @@ export default function(store){
       'event-type-filters': EventTypeFilters,
       'event-date-filters': EventDateFilters,
       'button-dropdown': ButtonDropdown,
+      'mobile-event-filters': MobileEventFilters,
     }
   })
 }

--- a/src/components/MobileEventFilters.vue
+++ b/src/components/MobileEventFilters.vue
@@ -1,0 +1,36 @@
+<template>
+  <div v-if="isFilterEventsOpen">
+    <div class="filter-events" :style="filterEventsTop">
+      <div class="filter-events-header">
+        <span>Filter events</span>
+        <span class="filter-events-close" @click="toggleFilterEvents">
+          ✖
+        </span>
+      </div>
+      <div class="filter-events-body">
+        <event-date-filters :show-title="true" :filters="filters" ></event-date-filters>
+        <event-type-filters :show-title="true" :filters="filters"></event-type-filters>
+        <button
+          class="filter-events-search"
+          @click="toggleFilterEvents"
+        >
+          Search events
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import EventTypeFilters from 'src/components/EventTypeFilters';
+import EventDateFilters from 'src/components/EventDateFilters';
+
+export default {
+  name: 'mobile-event-filters',
+  props: ['isFilterEventsOpen', 'filterEventsTop', 'toggleFilterEvents', 'filters'],
+  components: {
+    'event-type-filters': EventTypeFilters,
+    'event-date-filters': EventDateFilters,
+  }
+}
+</script>

--- a/src/store.js
+++ b/src/store.js
@@ -24,7 +24,7 @@ const store = new Vuex.Store({
   state: {
     events: [],
     zipcodes: {},
-    view: 'map',
+    view: 'list',
     filters: initialHash,
     selectedEventId: null
   },

--- a/src/templates/Header.html
+++ b/src/templates/Header.html
@@ -32,26 +32,14 @@
         </button>
       </div>
 
-      <div v-if="isFilterEventsOpen">
-        <div class="filter-events" :style="filterEventsTop">
-          <div class="filter-events-header">
-            <span>Filter events</span>
-            <span class="filter-events-close" @click="toggleFilterEvents">
-              ✖
-            </span>
-          </div>
-          <div class="filter-events-body">
-            <event-date-filters :show-title="true" :filters="filters" ></event-date-filters>
-            <event-type-filters :show-title="true" :filters="filters"></event-type-filters>
-            <button
-              class="filter-events-search"
-              @click="toggleFilterEvents"
-            >
-              Search events
-            </button>
-          </div>
-        </div>
-      </div>
+      <mobile-event-filters
+        :is-filter-events-open="isFilterEventsOpen"
+        :filter-events-top="filterEventsTop"
+        :toggle-filter-events="toggleFilterEvents"
+        :filters="filters"
+      >
+      </mobile-event-filters>
+
     </div>
 
     <div class="toolbar -desktop">


### PR DESCRIPTION
Toward #14 

Show the event list view initially, instead of the map, on mobile. Also extract the mobile event filters code into its own component, mostly so the initial loading experience on mobile is cleaner.