### PR TITLE
Flexbox fix affecting map in safari

### DIFF
--- a/src/assets/styles/layout.scss
+++ b/src/assets/styles/layout.scss
@@ -1,20 +1,18 @@
 .layout {
   height: 100vh;
-}
-
-.layout {
   display: flex;
   flex-direction: column;
 }
 
 .layout-main {
   flex: 1;
+  display: flex;
+  flex-direction: column;
 }
 
 .event-map,
 .event-list {
   display: none;
-  flex-direction: column;
 }
 
 .event-list.-active {
@@ -23,12 +21,11 @@
 
 .event-map.-active {
   display: flex;
-  height: 100%;
+  flex: 1;
 }
 
 @media (min-width: $breakpoint-large) {
   .layout-main {
-    display: flex;
     flex-direction: row;
     align-items: stretch;
     min-height: 0;


### PR DESCRIPTION
Fixes #109

Map wasn't working in safari in the mobile-ish layout because a flex container child was trying to specify 100% height -- safari is not into it, see http://stackoverflow.com/questions/33636796/chrome-safari-not-filling-100-height-of-flex-parent.

Fixes by further embracing the flex. I've tested this pretty thoroughly across browsers and it looks good.