### PR TITLE
Add hack to eventsReceived to make specified ids appear official

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -66,6 +66,16 @@ const store = new Vuex.Store({
   },
   mutations: {
     eventsReceived(state, events) {
+      // TEMP check events against list of also official event ids
+      // doing this becase ETL isn't picking up some email domains
+      // hack it up client-side
+      const alsoOfficialEventIds = [7928, 7929, 7930, 7931];
+      events.events.map(event => {
+        if (alsoOfficialEventIds.find(x => x == event.id)) {
+          event.is_official = true;
+        }
+      });
+
       state.events = events.events;
 
       const newEventTypes = Object.entries(events.categories).reduce((result, [category, { label }]) => {


### PR DESCRIPTION
Per request from @kpenning, adjust is_official of some events client-side to work around an issue with the ETL. Add more event ids as necessary to adjust further.