### PR TITLE
Switch to querystrings, preserve akid in links, fix zipcode bug

### DIFF
--- a/src/campaigns.js
+++ b/src/campaigns.js
@@ -38,11 +38,8 @@ export default function parse() {
   let options = campaigns[campaignName] || campaigns['default'];
 
   // replace source parameter, if available
-  if (params.source) {
-    options.source = params.source;
-  } else {
-    options.source = 'map';
-  }
+  options.source = params.source || 'map';
+  options.akid = params.akid || '';
 
   return options;
 };

--- a/src/campaigns.js
+++ b/src/campaigns.js
@@ -6,7 +6,8 @@ import vrLogoFile from 'assets/images/logo-second-chances.png';
 export default function parse() {
   // configure based on URL params (first hash, then querystring)
   let params = querystring.parse(window.location.hash.replace('#', ''));
-  if (!params) {
+
+  if (!Object.keys(params).length) {
     params = querystring.parse(window.location.search.replace('?', ''));
   }
 

--- a/src/components/EventCard.vue
+++ b/src/components/EventCard.vue
@@ -32,7 +32,7 @@ const displayDateFormat = 'dddd, MMM D h:mma';
 
 export default {
   name: 'event-card',
-  props: ['event', 'eventTypes', 'source'],
+  props: ['event', 'eventTypes', 'source', 'akid'],
   computed: {
     date() {
       return moment(this.event.start_datetime).format(displayDateFormat);
@@ -52,7 +52,7 @@ export default {
         .filter(Boolean);
     },
     url() {
-      return `https://go.peoplepower.org/event/${this.event.campaign}/${this.event.id}?source=${this.source}`;
+      return `https://go.peoplepower.org/event/${this.event.campaign}/${this.event.id}?source=${this.source}&akid=${this.akid}`;
     }
   }
 }

--- a/src/components/EventList.js
+++ b/src/components/EventList.js
@@ -10,7 +10,8 @@ export default function(store, opts){
     template: require('src/templates/EventList.html'),
     store,
     data: {
-      source: options.source
+      source: options.source,
+      akid: options.akid
     },
     computed: {
       events() {

--- a/src/components/EventMap.js
+++ b/src/components/EventMap.js
@@ -164,11 +164,12 @@ export default function(store, opts){
         
         eventIds.forEach(function(eventId, i) {
           const vm = new Vue({
-            template: '<event-card :event="event" :event-types="eventTypes" :source="source"></event-card>',
+            template: '<event-card :event="event" :event-types="eventTypes" :source="source" :akid="akid"></event-card>',
             data: {
               event: filteredEvents.find(ev => ev.id === eventId),
               eventTypes: eventTypes,
               source: options.source,
+              akid: options.akid
             },
             components: {
               'event-card': EventCard

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -8,8 +8,10 @@ export default function(opts) {
     template: require('src/templates/Footer.html'),
     data: {
       showACLU: options.showACLU,
+      source: options.source,
+      akid: options.akid,
       facebookUrl: 'https://www.facebook.com/sharer/sharer.php',
-      currentUrl: location.href
+      currentUrl: location.href.replace('akid=', 'referring_akid=')
     },
     computed: {
       shareUrl() {
@@ -26,7 +28,7 @@ export default function(opts) {
     },
     methods: {
       updateUrl() {
-        this.currentUrl = location.href
+        this.currentUrl = location.href.replace('akid=', 'referring_akid=')
       }
     }
   })

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -17,10 +17,12 @@ export default function(opts) {
       }
     },
     created() {
-      window.addEventListener('hashchange', this.updateUrl);
+      window.addEventListener('popstate', this.updateUrl);
+      window.addEventListener('pushstate', this.updateUrl);
     },
     beforeDestroy() {
-      window.removeEventListener('hashchange', this.updateUrl);
+      window.removeEventListener('popstate', this.updateUrl);
+      window.addEventListener('pushstate', this.updateUrl);
     },
     methods: {
       updateUrl() {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -3,6 +3,7 @@ import EventTypeFilters from 'src/components/EventTypeFilters';
 import EventDateFilters from 'src/components/EventDateFilters';
 import ButtonDropdown from 'src/components/ButtonDropdown';
 import MobileEventFilters from 'src/components/MobileEventFilters';
+import querystring from 'querystring';
 
 export default function(store, opts){
   var options = opts || {};
@@ -47,7 +48,19 @@ export default function(store, opts){
         if (/^\d{5}$/.test(newZipcode) || !newZipcode) {
           store.dispatch('setFilters',{zipcode: newZipcode });
         }
+      },
+      updateFilters() {
+        const newFilters = querystring.parse(location.search.replace(/^\?/, ''))
+        if (newFilters != store.state.filters) {
+          store.dispatch('setFilters', newFilters);
+        }
       }
+    },
+    created() {
+      window.addEventListener('popstate', this.updateFilters);
+    },
+    beforeDestroy() {
+      window.addEventListener('popstate', this.updateFilters);
     },
     components: {
       'event-type-filters': EventTypeFilters,

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -21,6 +21,7 @@ export default function(store, opts){
         // for smaller screens
         filterEventsTop: { top: 0 },
         source: options.source,
+        akid: options.akid
       };
     },
     computed: {
@@ -50,7 +51,7 @@ export default function(store, opts){
         }
       },
       updateFilters() {
-        const newFilters = querystring.parse(location.search.replace(/^\?/, ''))
+        const newFilters = querystring.parse(window.location.search.replace(/^\?/, ''))
         if (newFilters != store.state.filters) {
           store.dispatch('setFilters', newFilters);
         }

--- a/src/initialize.js
+++ b/src/initialize.js
@@ -27,7 +27,7 @@ store.dispatch('loadZips')
 store.dispatch('loadUSStates')
 
 // Set initial event filters based on campaign
-if (options.filters) {
+if (Object.keys(options.filters).length) {
   store.state.filters = options.filters;
 }
 

--- a/src/store.js
+++ b/src/store.js
@@ -6,14 +6,20 @@ import querystring from 'querystring';
 
 //Save the initial hash of the window when Vue initializes.
 //We'll use these values to populate the initial store filter values
-const initialHash = querystring.parse(window.location.hash.replace(/^#/, ''))
+const initialHash = querystring.parse(window.location.hash.replace(/^#/, '') ||
+                                      window.location.search.replace(/^\?/, ''))
 
-//A small Vuex plugin that will update the browsers location hash whenever
+//A small Vuex plugin that will update the browsers location querystring whenever
 //the setFilters mutation occurs
 const hashUpdaterPlugin = (store) => {
   store.subscribe((mutation, state) => {
     if(mutation.type === "filtersReceived"){
-      window.location.hash = querystring.stringify(state.filters)
+      const newQs = '?' + querystring.stringify(state.filters)
+      if (newQs !== window.location.search) {
+        window.history.pushState(
+          null, null, '?'+querystring.stringify(state.filters))
+        window.dispatchEvent(new Event('pushstate'))
+      }
     }
   })
 }

--- a/src/templates/EventList.html
+++ b/src/templates/EventList.html
@@ -3,8 +3,9 @@
     v-for="event in filteredEvents"
     :selected="selectedEventIds.includes(event.id)"
     :source="source"
+    :akid="akid"
   >
-    <event-card :event="event" :event-types="eventTypes" :source="source"></event-card>
+    <event-card :event="event" :event-types="eventTypes" :source="source" :akid="akid"></event-card>
   </event-list-item>
   <div
     v-if="isSelectedZipcodeInvalid"

--- a/src/templates/Footer.html
+++ b/src/templates/Footer.html
@@ -1,6 +1,7 @@
 <div class='footer'>
   <div class='footer-buttons'>
-    <a target="_blank" class='btn host-btn' href='https://go.peoplepower.org/signup/host_new?source=map'>
+    <a target="_blank" class='btn host-btn'
+       :href="'https://go.peoplepower.org/signup/host_new?source='+source+'&akid='+akid">
       Host an event
     </a>
     <a target="_blank" class='btn share-btn' :href="shareUrl">

--- a/src/templates/Header.html
+++ b/src/templates/Header.html
@@ -74,7 +74,7 @@
           <a
             v-if="hostEventLink"
             class="btn"
-            :href="hostEventLink+'?source='+source"
+            :href="hostEventLink+'?source='+source+'&akid='+akid"
             target="_blank"
           >
             Host an event
@@ -82,7 +82,7 @@
           <a
             v-else
             class="btn"
-            href="https://go.peoplepower.org/signup/host_new?source=map"
+            :href="'https://go.peoplepower.org/signup/host_new?source='+source+'&akid='+akid"
             target="_blank"
           >
             Host an event


### PR DESCRIPTION
* Construct links to the map using querystrings instead of hashes, since it's more familiar to partners and is less prone to being mangled by actionkit emails
 * But continue to support hash params for backwards compatibility with links in the wild

* If an `akid=` param is present, pass it through to actionkit event rsvp pages and event host pages in addition to `source=`
 * When sharing map on facebook, replace it with `referring_akid=`
 * Add `source=` passthrough to a few more links that were missing it

* Fix map.peoplepower.org/#zipcode=11111 // map.peoplepower.org/?zipcode=11111 bug that was recently introduced

* When zip or other filters are changed by end user, update querystring in the browser window with pushstate so current map UI state is always direct-linkable

* Listen to popstate events so when back button is pressed, the map UI state changes too