### PR TITLE
Only ever show points within current map pane

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,11 +55,13 @@
     "webpack-merge": "^4.1.0"
   },
   "dependencies": {
+    "@turf/helpers": "^5.0.1",
     "babel-polyfill": "^6.23.0",
     "load-script": "^1.0.0",
     "mapbox-gl": "^0.35.0",
     "moment": "^2.18.1",
     "pikaday": "^1.5.1",
+    "turf-inside": "^3.0.12",
     "vue": "^2.2.5",
     "vuex": "^2.2.1",
     "xhr": "^2.4.0"

--- a/src/assets/styles/event_list.scss
+++ b/src/assets/styles/event_list.scss
@@ -31,5 +31,8 @@
     &.-selected {
       border-left: solid 5px $aclu-blue;
     }
+    &.-hovered {
+      background: $highlight;
+    }    
   }
 }

--- a/src/assets/styles/variables.scss
+++ b/src/assets/styles/variables.scss
@@ -11,6 +11,7 @@ $light-gray: #E0DFE0;
 $dark-red: #A30800;
 $white: #FFF;
 $black: #000;
+$highlight: #FFFFE0;
 
 $text-size: 18px;
 $offset: $text-size;

--- a/src/components/EventList.js
+++ b/src/components/EventList.js
@@ -35,6 +35,9 @@ export default function(store, opts){
       selectedEventIds() {
         return store.state.selectedEventIds;
       },
+      hoveredEventIds() {
+        return store.state.hoveredEventIds;
+      },
       isSelectedZipcodeInvalid() {
         return this.filters.zipcode &&
           Object.keys(this.zipcodes).length &&

--- a/src/components/EventListItem.vue
+++ b/src/components/EventListItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="root" :class="['event-list-item', { '-selected': selected }]">
+  <div ref="root" :class="['event-list-item', { '-selected': selected, '-hovered': hovered }]">
     <slot></slot>
   </div>
 </template>
@@ -7,13 +7,18 @@
 <script>
 export default {
   name: 'event-list-item',
-  props: ['selected', 'onSelect'],
+  props: ['selected', 'hovered', 'onSelect'],
   watch: {
     selected() {
       if (this.selected) {
         this.$refs.root.scrollIntoView({ behavior: 'smooth' });
       }
-    }
+    },
+    hovered() {
+      if (this.hovered) {
+        this.$refs.root.scrollIntoView({ behavior: 'smooth' });
+      }
+    }    
   }
 }
 </script>

--- a/src/store.js
+++ b/src/store.js
@@ -33,7 +33,9 @@ const store = new Vuex.Store({
     us_states: {},
     view: 'list',
     filters: initialHash,
+    map: null,
     selectedEventIds: [],
+    hoveredEventIds: [],
     // We initialize eventTypes just with our "virtual" event type,
     // and the rest are loaded from the server
     eventTypes: {
@@ -79,6 +81,11 @@ const store = new Vuex.Store({
       process.nextTick(() => {
         commit('filtersReceived', filters);
       });
+    },
+    setMap({ commit }, { map }) {
+      process.nextTick(() => {
+        commit('mapChanged', map);
+      });
     }
   },
   mutations: {
@@ -117,13 +124,21 @@ const store = new Vuex.Store({
     filtersReceived(state, filters) {
       state.filters = {...state.filters, ...filters};
     },
+    mapChanged(state, map) {
+      state.map = map;
+      state.hoveredEventIds = [];
+    },
     eventSelected(state, eventIds) {
       state.selectedEventIds = eventIds;
+    },
+    eventHovered(state, eventIds) {
+      state.hoveredEventIds = eventIds;
     }
   },
   getters: {
     filteredEvents: state => {
-      return computeFilteredEvents(state.events, state.filters, state.zipcodes)
+      return computeFilteredEvents(state.events, state.map,
+                                   state.filters, state.zipcodes)
     }
   },
   plugins: [hashUpdaterPlugin]

--- a/src/templates/EventList.html
+++ b/src/templates/EventList.html
@@ -2,6 +2,7 @@
   <event-list-item
     v-for="event in filteredEvents"
     :selected="selectedEventIds.includes(event.id)"
+    :hovered="hoveredEventIds.includes(event.id)"
     :source="source"
     :akid="akid"
   >

--- a/yarn.lock
+++ b/yarn.lock
@@ -4930,6 +4930,12 @@ turf-helpers@^3.0.12:
   version "3.0.12"
   resolved "https://registry.yarnpkg.com/turf-helpers/-/turf-helpers-3.0.12.tgz#dd4272e74b3ad7c96eecb7ae5c57fe8eca544b7b"
 
+turf-inside@^3.0.12:
+  version "3.0.12"
+  resolved "https://registry.yarnpkg.com/turf-inside/-/turf-inside-3.0.12.tgz#9ba40fa6eed63bec7e7d88aa6427622c4df07066"
+  dependencies:
+    turf-invariant "^3.0.12"
+
 turf-invariant@^3.0.12:
   version "3.0.12"
   resolved "https://registry.yarnpkg.com/turf-invariant/-/turf-invariant-3.0.12.tgz#3b95253953991ebd962dd35d4f6704c287de8ebe"


### PR DESCRIPTION
and replot on every zoom/pan; also highlight and scrollTo current hovered-over event in list

This is now live, but still to do:

* replot during pan/zoom instead of after (if doable without being laggy)
* add a mobile-only "reset view" button since it's now hard on mobile to go back to seeing a list of all events
* maaaybe default to listing all events instead of all events in initial viewport if initial viewport is default (i.e. not zip/state specific)